### PR TITLE
[WIP] Rdma device rename in container

### DIFF
--- a/pkg/rdma/rdma.go
+++ b/pkg/rdma/rdma.go
@@ -2,6 +2,7 @@ package rdma
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 )
@@ -18,12 +19,18 @@ func NewRdmaManager() RdmaManager {
 type RdmaManager interface {
 	// Move RDMA device from current network namespace to network namespace
 	MoveRdmaDevToNs(rdmaDev string, netNs ns.NetNS) error
+	// Get RDMA devices in the current network namespace
+	GetRdmaDeviceList() ([]string, error)
 	// Get RDMA devices associated with the given PCI device in D:B:D.f format e.g 0000:04:00.0
 	GetRdmaDevsForPciDev(pciDev string) ([]string, error)
 	// Get RDMA subsystem namespace awareness mode ["exclusive" | "shared"]
 	GetSystemRdmaMode() (string, error)
 	// Set RDMA subsystem namespace awareness mode ["exclusive" | "shared"]
 	SetSystemRdmaMode(mode string) error
+	// Change RDMA device name
+	SetRdmaDevName(oldName string, newName string) error
+	// Set RDMA device temporary name
+	SetRdmaDevTempName(rdmaDev string) (string, error)
 }
 
 type rdmaManagerNetlink struct {
@@ -56,4 +63,40 @@ func (rmn *rdmaManagerNetlink) GetSystemRdmaMode() (string, error) {
 // Set RDMA subsystem namespace awareness mode ["exclusive" | "shared"]
 func (rmn *rdmaManagerNetlink) SetSystemRdmaMode(mode string) error {
 	return rmn.rdmaOps.RdmaSystemSetNetnsMode(mode)
+}
+
+// Change RDMA device name
+func (rmn *rdmaManagerNetlink) SetRdmaDevName(oldName string, newName string) error {
+	rdmaLink, err := rmn.rdmaOps.RdmaLinkByName(oldName)
+	if err != nil {
+		return fmt.Errorf("cannot find RDMA link from name: %s", oldName)
+	}
+	err = rmn.rdmaOps.RdmaLinkSetName(rdmaLink, newName)
+	if err != nil {
+		return fmt.Errorf("failed to change RDMA device name from %s to %s. %v", oldName, newName, err)
+	}
+	return nil
+}
+
+// Get RDMA devices in the current network namespace
+func (rmn *rdmaManagerNetlink) GetRdmaDeviceList() ([]string, error) {
+	links, err := rmn.rdmaOps.GetRdmaLinkList()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(links))
+	for _, link := range links {
+		names = append(names, link.Attrs.Name)
+	}
+	return names, nil
+}
+
+// Set RDMA device to a unique temporary name
+func (rmn *rdmaManagerNetlink) SetRdmaDevTempName(rdmaDev string) (string, error) {
+	link, err := rmn.rdmaOps.RdmaLinkByName(rdmaDev)
+	if err != nil {
+		return "", err
+	}
+	tmpName := fmt.Sprintf("rdmadev_%d", link.Attrs.Index)[:(syscall.IFNAMSIZ - 1)]
+	return tmpName, rmn.rdmaOps.RdmaLinkSetName(link, tmpName)
 }

--- a/pkg/rdma/rdma_ops.go
+++ b/pkg/rdma/rdma_ops.go
@@ -11,12 +11,16 @@ type RdmaBasicOps interface {
 	RdmaLinkByName(name string) (*netlink.RdmaLink, error)
 	// Equivalent to netlink.RdmaLinkSetNsFd(...)
 	RdmaLinkSetNsFd(link *netlink.RdmaLink, fd uint32) error
+	// Equivalent to netlink.RdmaLinkSetName(...)
+	RdmaLinkSetName(link *netlink.RdmaLink, name string) error
 	// Equivalent to netlink.RdmaSystemGetNetnsMode(...)
 	RdmaSystemGetNetnsMode() (string, error)
 	// Equivalent to netlink.RdmaSystemSetNetnsMode(...)
 	RdmaSystemSetNetnsMode(newMode string) error
 	// Equivalent to rdmamap.GetRdmaDevicesForPcidev(...)
 	GetRdmaDevicesForPcidev(pcidevName string) []string
+	// Equivalent to netlink.RdmaLinkList()
+	GetRdmaLinkList() ([]*netlink.RdmaLink, error)
 }
 
 func newRdmaBasicOps() RdmaBasicOps {
@@ -36,6 +40,11 @@ func (rdma *rdmaBasicOpsImpl) RdmaLinkSetNsFd(link *netlink.RdmaLink, fd uint32)
 	return netlink.RdmaLinkSetNsFd(link, fd)
 }
 
+// Equivalent to netlink.RdmaLinkSetName(...)
+func (rdma *rdmaBasicOpsImpl) RdmaLinkSetName(link *netlink.RdmaLink, name string) error {
+	return netlink.RdmaLinkSetName(link, name)
+}
+
 // Equivalent to netlink.RdmaSystemGetNetnsMode(...)
 func (rdma *rdmaBasicOpsImpl) RdmaSystemGetNetnsMode() (string, error) {
 	return netlink.RdmaSystemGetNetnsMode()
@@ -49,4 +58,9 @@ func (rdma *rdmaBasicOpsImpl) RdmaSystemSetNetnsMode(newMode string) error {
 // Equivalent to rdmamap.GetRdmaDevicesForPcidev(...)
 func (rdma *rdmaBasicOpsImpl) GetRdmaDevicesForPcidev(pcidevName string) []string {
 	return rdmamap.GetRdmaDevicesForPcidev(pcidevName)
+}
+
+// Equivalent to netlink.RdmaLinkList()
+func (rdma *rdmaBasicOpsImpl) GetRdmaLinkList() ([]*netlink.RdmaLink, error) {
+	return netlink.RdmaLinkList()
 }


### PR DESCRIPTION
This PR adds the functionality of providing incrementing RDMA device name in container.
allowing  for consistent RDMA device names in containers e.g `mlx5_0` for the first RDMA enabled network, `mlx5_1` for the second RDMA enabled network etc...

**Missing:**
- [ ] Merge of https://github.com/vishvananda/netlink/pull/533 and update dependency
- [ ] Kernel support for namespace unique RDMA device name instead of globally unique
- [ ] Unit-tests
