### PR TITLE
Lock the OS thread to adviod ns ops are done for different thread

### DIFF
--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -19,6 +20,14 @@ import (
 	rdmatypes "github.com/k8snetworkplumbingwg/rdma-cni/pkg/types"
 	"github.com/k8snetworkplumbingwg/rdma-cni/pkg/utils"
 )
+
+//nolint:gochecknoinits
+func init() {
+	// this ensures that main runs only on main thread (thread group leader).
+	// since namespace ops (unshare, setns) are done for a single thread, we
+	// must ensure that the goroutine does not jump from OS thread to thread
+	runtime.LockOSThread()
+}
 
 // Sets the initial log level configurations
 // this is overridden by the "debug" CNI arg


### PR DESCRIPTION
We developed a DRA plugin, and I would invoke the RDMA CNI in the DRA plugin. DRA Plugin is running as host network

We occasionally encountered situations where the entire dra-plugin would exit unexpectedly when calling rdma-cni. After merging the changes from this PR and recompiling, we found that the issue no longer occurred.

When it comes to operations involving namespaces (ns), we should ensure that all namespace-related operations are performed within the same thread as much as possible. All other CNI projects also follow this practice.

see https://github.com/containernetworking/plugins/blob/48a4ae5ab5f12966c935a793b1316ec13dd05a3e/plugins/main/macvlan/macvlan.go#L62