### PR TITLE
update git ignore to not exclude internal build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@
 # Folders
 .gopath/
 .idea/
-bin/
-build/
+/bin/
+/build/


### PR DESCRIPTION
when using vendor there is a file in git that gets ignored and it should not

```
git status --porcelain --ignored
!! bin/
!! build/
!! vendor/github.com/onsi/ginkgo/v2/ginkgo/build/
```