### PR TITLE
Specify patch version in go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/rdma-cni
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/Mellanox/rdmamap v1.1.0


### PR DESCRIPTION
As of go1.21, is reccommended to use patch version in the `go vX.Y.Z` directive

https://tip.golang.org/doc/go1.21#tools