### PR TITLE
Bump rdma-cni to Go 1.26

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -9,7 +9,7 @@ jobs:
     name: build
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
         os: [ubuntu-22.04]
         goos: [linux]
         goarch: [amd64]
@@ -35,7 +35,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: check out code into the Go module directory
         uses: actions/checkout@v7
       - name: run unit-test
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Check out code into the Go module directory
         uses: actions/checkout@v7
       - name: Go test with coverage

--- a/.github/workflows/static-scan.yaml
+++ b/.github/workflows/static-scan.yaml
@@ -8,7 +8,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: checkout PR
         uses: actions/checkout@v7
       - name: run make lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/rdma-cni
 
-go 1.25.3
+go 1.26
 
 require (
 	github.com/Mellanox/rdmamap v1.2.0


### PR DESCRIPTION
## Summary

Bumps the rdma-cni project from Go 1.25.3 to Go 1.26, updating all relevant configuration files to use the new Go version.

## Key Changes

- Updated `go.mod` go directive from `1.25.3` to `1.26`
- Updated GitHub Actions workflow `buildtest.yaml` Go version from `1.25.x` to `1.26.x` across all three jobs (build, unit-test, coverage)
- Updated GitHub Actions workflow `static-scan.yaml` Go version from `1.25.x` to `1.26.x`

## Notes

- golangci-lint remains at v2.7.2 as it is already compatible with Go 1.26
- No Kubernetes packages or code-generator dependencies to update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go toolchain requirement to Go 1.26.
  * Aligned automated build, test, coverage, and static analysis workflows with Go 1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->