### PR TITLE
fix: validate deviceID and cache path components against path traversal

### DIFF
--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -221,7 +221,16 @@ func (plugin *rdmaCniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	state.DeviceID = conf.DeviceID
 	state.SandboxRdmaDevName = rdmaDev
 	state.ContainerRdmaDevName = rdmaDev
-	pRef := plugin.stateCache.GetStateRef(conf.Name, args.ContainerID, args.IfName)
+	pRef, err := plugin.stateCache.GetStateRef(conf.Name, args.ContainerID, args.IfName)
+	if err != nil {
+		restoreErr := plugin.moveRdmaDevFromNs(rdmaDev, args.Netns)
+		if restoreErr != nil {
+			return fmt.Errorf(
+				"invalid state reference %v, failed while restoring namespace for RDMA device %s. %v",
+				err, rdmaDev, restoreErr)
+		}
+		return fmt.Errorf("invalid state reference: %v", err)
+	}
 	err = plugin.stateCache.Save(pRef, &state)
 	if err != nil {
 		// Move RDMA dev back to current namespace
@@ -260,7 +269,11 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 
 	// Load RDMA device state from cache
 	rdmaState := rdmatypes.RdmaNetState{}
-	pRef := plugin.stateCache.GetStateRef(conf.Name, args.ContainerID, args.IfName)
+	pRef, err := plugin.stateCache.GetStateRef(conf.Name, args.ContainerID, args.IfName)
+	if err != nil {
+		log.Warn().Msgf("failed to construct state reference, skipping cleanup. %v", err)
+		return nil
+	}
 	err = plugin.stateCache.Load(pRef, &rdmaState)
 	if err != nil {
 		log.Warn().Msgf("failed to load cache entry(%q). it may have been deleted by a previous CMD_DEL call. %v", pRef, err)
@@ -284,20 +297,19 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 // getRDMADevice returns the first RDMA device found for the given deviceID.
 func (plugin *rdmaCniPlugin) getRDMADevice(deviceID string) (string, error) {
 	var rdmaDevs []string
-	if utils.IsPCIAddress(deviceID) {
+	switch {
+	case utils.IsPCIAddress(deviceID):
 		rdmaDevs = plugin.rdmaManager.GetRdmaDevsForPciDev(deviceID)
-		if len(rdmaDevs) == 0 {
-			return "", errors.New("no RDMA devices found")
-		}
-	} else {
+	case utils.IsAuxDevAddress(deviceID):
 		rdmaDevs = plugin.rdmaManager.GetRdmaDevsForAuxDev(deviceID)
-		if len(rdmaDevs) == 0 {
-			return "", errors.New("no RDMA devices found")
-		}
+	default:
+		return "", fmt.Errorf("invalid device ID format: %q", deviceID)
 	}
 
+	if len(rdmaDevs) == 0 {
+		return "", errors.New("no RDMA devices found")
+	}
 	if len(rdmaDevs) != 1 {
-		// Expecting exactly one RDMA device
 		return "", fmt.Errorf(
 			"discovered more than one RDMA device %v. Unsupported state", rdmaDevs)
 	}

--- a/cmd/rdma/main_test.go
+++ b/cmd/rdma/main_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Main", func() {
 				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
 				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{rdmaDev}, nil)
 				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
-				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"), nil)
 				expectedState := generateRdmaNetState(pciDev, rdmaDev, rdmaDev)
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
 				err := plugin.CmdAdd(&args)
@@ -256,7 +256,7 @@ var _ = Describe("Main", func() {
 				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
 				rdmaMgrMock.On("GetRdmaDevsForAuxDev", auxDev).Return([]string{rdmaDev}, nil)
 				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
-				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"), nil)
 				expectedState := generateRdmaNetState(auxDev, rdmaDev, rdmaDev)
 				stateCacheMock.On("Save", mock.AnythingOfType("cache.StateRef"), &expectedState).Return(nil)
 				err := plugin.CmdAdd(&args)
@@ -265,7 +265,71 @@ var _ = Describe("Main", func() {
 				stateCacheMock.AssertExpectations(t)
 			})
 		})
-		// TODO(adrian): Add additional tests to cover bad flows / differen network configurations
+		Context("GetStateRef returns error", func() {
+			It("Should restore RDMA device to original namespace and return error", func() {
+				pciDev := "0000:04:00.5"
+				netName := "net/with/slashes"
+				rdmaDev := "mlx5_4"
+				cIfname := "net1"
+				cid := "a1b2c3d4e5f6"
+				cnsPath := "/proc/12444/ns/net"
+				cns, _ := dummyNsMgr.GetNS(cnsPath)
+				curNs, _ := dummyNsMgr.GetCurrentNS()
+				netconf := generateNetConfCmdAdd(netName, cIfname, pciDev)
+				args := generateArgs(cnsPath, cid, cIfname, &netconf)
+				rdmaMgrMock.On("GetSystemRdmaMode").Return(rdma.RdmaSysModeExclusive, nil)
+				rdmaMgrMock.On("GetRdmaDevsForPciDev", pciDev).Return([]string{rdmaDev}, nil)
+				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, cns).Return(nil)
+				rdmaMgrMock.On("MoveRdmaDevToNs", rdmaDev, curNs).Return(nil)
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(
+					cache.StateRef(""), fmt.Errorf("invalid state ref component: %q", netName))
+				err := plugin.CmdAdd(&args)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid state reference"))
+				rdmaMgrMock.AssertExpectations(t)
+				stateCacheMock.AssertExpectations(t)
+			})
+		})
+	})
+
+	Describe("Test getRDMADevice()", func() {
+		Context("Input validation for non-PCI device IDs", func() {
+			It("Should reject deviceID containing path traversal components", func() {
+				_, err := plugin.getRDMADevice("../../pci/devices/0000:03:00.0")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid device ID"))
+			})
+
+			It("Should reject deviceID containing forward slashes", func() {
+				_, err := plugin.getRDMADevice("foo/bar")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid device ID"))
+			})
+
+			It("Should reject deviceID that is just dot-dot", func() {
+				_, err := plugin.getRDMADevice("..")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid device ID"))
+			})
+
+			It("Should accept valid auxiliary device ID", func() {
+				validAuxDev := "mlx5_core.sf.4"
+				rdmaMgrMock.On("GetRdmaDevsForAuxDev", validAuxDev).Return([]string{"mlx5_0"})
+				dev, err := plugin.getRDMADevice(validAuxDev)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dev).To(Equal("mlx5_0"))
+				rdmaMgrMock.AssertExpectations(t)
+			})
+
+			It("Should accept valid PCI device ID", func() {
+				validPciDev := "0000:04:00.5"
+				rdmaMgrMock.On("GetRdmaDevsForPciDev", validPciDev).Return([]string{"mlx5_0"})
+				dev, err := plugin.getRDMADevice(validPciDev)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dev).To(Equal("mlx5_0"))
+				rdmaMgrMock.AssertExpectations(t)
+			})
+		})
 	})
 
 	Describe("Test CmdDel()", func() {
@@ -281,7 +345,7 @@ var _ = Describe("Main", func() {
 				rdmaState := generateRdmaNetState(pciDev, rdmaDev, rdmaDev)
 				netconf := generateNetConfCmdDel(netName)
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
-				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"), nil)
 				stateCacheMock.On("Load", mock.AnythingOfType("cache.StateRef"),
 					mock.AnythingOfType("*types.RdmaNetState")).Return(nil).Run(func(args mock.Arguments) {
 					arg := args.Get(1).(*rdmaTypes.RdmaNetState)
@@ -305,7 +369,7 @@ var _ = Describe("Main", func() {
 				rdmaState := generateRdmaNetState(auxDev, rdmaDev, rdmaDev)
 				netconf := generateNetConfCmdDel(netName)
 				args := generateArgs(cnsPath, cid, cIfname, &netconf)
-				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"))
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(cache.StateRef("some-ref"), nil)
 				stateCacheMock.On("Load", mock.AnythingOfType("cache.StateRef"),
 					mock.AnythingOfType("*types.RdmaNetState")).Return(nil).Run(func(args mock.Arguments) {
 					arg := args.Get(1).(*rdmaTypes.RdmaNetState)
@@ -319,7 +383,23 @@ var _ = Describe("Main", func() {
 				stateCacheMock.AssertExpectations(t)
 			})
 		})
-		// TODO(adrian): Add additional tests to cover bad flows / different network configurations
+		Context("GetStateRef returns error", func() {
+			It("Should return nil without attempting cleanup", func() {
+				netName := "net/with/slashes"
+				cIfname := "net1"
+				cid := "a1b2c3d4e5f6"
+				cnsPath := "/proc/12444/ns/net"
+				netconf := generateNetConfCmdDel(netName)
+				args := generateArgs(cnsPath, cid, cIfname, &netconf)
+				stateCacheMock.On("GetStateRef", netName, cid, cIfname).Return(
+					cache.StateRef(""), fmt.Errorf("invalid state ref component: %q", netName))
+				err := plugin.CmdDel(&args)
+				Expect(err).ToNot(HaveOccurred())
+				stateCacheMock.AssertExpectations(t)
+				stateCacheMock.AssertNotCalled(t, "Load")
+				stateCacheMock.AssertNotCalled(t, "Delete")
+			})
+		})
 	})
 
 	Describe("Test CmdCheck()", func() {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -21,7 +21,7 @@ type StateRef string
 
 type StateCache interface {
 	// Get State reference identifier for <networkName, containerID, interfaceName>
-	GetStateRef(network string, cid string, ifname string) StateRef
+	GetStateRef(network string, cid string, ifname string) (StateRef, error)
 	// Save state to cache
 	Save(ref StateRef, state interface{}) error
 	// Load state from cache
@@ -40,8 +40,13 @@ type FsStateCache struct {
 	fsOps    FileSystemOps
 }
 
-func (sc *FsStateCache) GetStateRef(network, cid, ifname string) StateRef {
-	return StateRef(strings.Join([]string{network, cid, ifname}, "-"))
+func (sc *FsStateCache) GetStateRef(network, cid, ifname string) (StateRef, error) {
+	for _, component := range []string{network, cid, ifname} {
+		if strings.ContainsAny(component, "/\\") {
+			return "", fmt.Errorf("invalid state ref component: %q", component)
+		}
+	}
+	return StateRef(strings.Join([]string{network, cid, ifname}, "-")), nil
 }
 
 func (sc *FsStateCache) Save(ref StateRef, state interface{}) error {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -23,8 +23,9 @@ var _ = Describe("Cache - Simple marshall-able state-object cache", func() {
 	Describe("Get State reference", func() {
 		Context("Basic call", func() {
 			It("Should return <network>-<cid>-<ifname>", func() {
-				Expect(stateCache.GetStateRef("myNet", "containerUniqueIdentifier", "net1")).To(
-					BeEquivalentTo("myNet-containerUniqueIdentifier-net1"))
+				ref, err := stateCache.GetStateRef("myNet", "containerUniqueIdentifier", "net1")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ref).To(BeEquivalentTo("myNet-containerUniqueIdentifier-net1"))
 			})
 		})
 	})
@@ -32,7 +33,9 @@ var _ = Describe("Cache - Simple marshall-able state-object cache", func() {
 	Describe("Save and Load State", func() {
 		var sRef StateRef
 		JustBeforeEach(func() {
-			sRef = stateCache.GetStateRef("mynet", "cid", "net1")
+			var err error
+			sRef, err = stateCache.GetStateRef("mynet", "cid", "net1")
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("Save and Load with marshallable object", func() {
@@ -57,7 +60,9 @@ var _ = Describe("Cache - Simple marshall-able state-object cache", func() {
 	Describe("Delete State", func() {
 		var sRef StateRef
 		JustBeforeEach(func() {
-			sRef = stateCache.GetStateRef("mynet", "cid", "net1")
+			var err error
+			sRef, err = stateCache.GetStateRef("mynet", "cid", "net1")
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("Delete a saved state", func() {
@@ -73,10 +78,57 @@ var _ = Describe("Cache - Simple marshall-able state-object cache", func() {
 		})
 		Context("Delete a non existent state", func() {
 			It("Should Fail", func() {
-				altRef := stateCache.GetStateRef("alt-mynet", "cid", "net1")
+				altRef, err := stateCache.GetStateRef("alt-mynet", "cid", "net1")
+				Expect(err).ToNot(HaveOccurred())
 				Expect(stateCache.Delete(altRef)).To(HaveOccurred())
-				_, err := fs.Stat(path.Join(CacheDir, string(altRef)))
+				_, err = fs.Stat(path.Join(CacheDir, string(altRef)))
 				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Input validation for state ref components", func() {
+		Context("Network name containing path traversal", func() {
+			It("Should reject network name with path traversal components", func() {
+				maliciousName := "../../../../tmp/evil"
+				_, err := stateCache.GetStateRef(maliciousName, "abc123", "net1")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid state ref component"))
+			})
+
+			It("Should reject network name with forward slashes", func() {
+				_, err := stateCache.GetStateRef("net/with/slashes", "abc123", "net1")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid state ref component"))
+			})
+
+		})
+
+		Context("Container ID containing path traversal", func() {
+			It("Should reject container ID with path traversal components", func() {
+				_, err := stateCache.GetStateRef("mynet", "../../../tmp/evil", "net1")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid state ref component"))
+			})
+
+			It("Should reject container ID with forward slashes", func() {
+				_, err := stateCache.GetStateRef("mynet", "cid/with/slashes", "net1")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid state ref component"))
+			})
+		})
+
+		Context("Interface name containing path traversal", func() {
+			It("Should reject interface name with path traversal components", func() {
+				_, err := stateCache.GetStateRef("mynet", "abc123", "net/../1")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid state ref component"))
+			})
+
+			It("Should reject interface name with forward slashes", func() {
+				_, err := stateCache.GetStateRef("mynet", "abc123", "net/1")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid state ref component"))
 			})
 		})
 	})

--- a/pkg/cache/mocks/StateCache.go
+++ b/pkg/cache/mocks/StateCache.go
@@ -88,7 +88,7 @@ func (_c *MockStateCache_Delete_Call) RunAndReturn(run func(ref cache.StateRef) 
 }
 
 // GetStateRef provides a mock function for the type MockStateCache
-func (_mock *MockStateCache) GetStateRef(network string, cid string, ifname string) cache.StateRef {
+func (_mock *MockStateCache) GetStateRef(network string, cid string, ifname string) (cache.StateRef, error) {
 	ret := _mock.Called(network, cid, ifname)
 
 	if len(ret) == 0 {
@@ -96,12 +96,21 @@ func (_mock *MockStateCache) GetStateRef(network string, cid string, ifname stri
 	}
 
 	var r0 cache.StateRef
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) (cache.StateRef, error)); ok {
+		return returnFunc(network, cid, ifname)
+	}
 	if returnFunc, ok := ret.Get(0).(func(string, string, string) cache.StateRef); ok {
 		r0 = returnFunc(network, cid, ifname)
 	} else {
 		r0 = ret.Get(0).(cache.StateRef)
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(network, cid, ifname)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockStateCache_GetStateRef_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStateRef'
@@ -140,12 +149,12 @@ func (_c *MockStateCache_GetStateRef_Call) Run(run func(network string, cid stri
 	return _c
 }
 
-func (_c *MockStateCache_GetStateRef_Call) Return(stateRef cache.StateRef) *MockStateCache_GetStateRef_Call {
-	_c.Call.Return(stateRef)
+func (_c *MockStateCache_GetStateRef_Call) Return(stateRef cache.StateRef, err error) *MockStateCache_GetStateRef_Call {
+	_c.Call.Return(stateRef, err)
 	return _c
 }
 
-func (_c *MockStateCache_GetStateRef_Call) RunAndReturn(run func(network string, cid string, ifname string) cache.StateRef) *MockStateCache_GetStateRef_Call {
+func (_c *MockStateCache_GetStateRef_Call) RunAndReturn(run func(network string, cid string, ifname string) (cache.StateRef, error)) *MockStateCache_GetStateRef_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -48,8 +48,18 @@ func GetVfPciDevFromMAC(mac string) (string, error) {
 	return dev, err
 }
 
+var pciAddressRegex = regexp.MustCompile(`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$`)
+
+// Matches the kernel auxiliary bus naming convention: <KBUILD_MODNAME>.<name>.<id>
+// constructed via dev_set_name("%s.%s.%d", modname, auxdev->name, auxdev->id).
+var auxDevRegex = regexp.MustCompile(`^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.\d+$`)
+
 // IsPCIAddress returns whether the input is a valid PCI address.
 func IsPCIAddress(pciAddress string) bool {
-	re := regexp.MustCompile(`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$`)
-	return re.MatchString(pciAddress)
+	return pciAddressRegex.MatchString(pciAddress)
+}
+
+// IsAuxDevAddress returns whether the input matches the kernel auxiliary bus device naming convention.
+func IsAuxDevAddress(auxDev string) bool {
+	return auxDevRegex.MatchString(auxDev)
 }

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Utils", func() {
+	Describe("IsPCIAddress", func() {
+		It("Should accept valid PCI address", func() {
+			Expect(IsPCIAddress("0000:04:00.5")).To(BeTrue())
+		})
+		It("Should accept PCI address with hex digits", func() {
+			Expect(IsPCIAddress("abcd:ef:01.7")).To(BeTrue())
+		})
+		It("Should reject empty string", func() {
+			Expect(IsPCIAddress("")).To(BeFalse())
+		})
+		It("Should reject PCI address with invalid function number", func() {
+			Expect(IsPCIAddress("0000:04:00.8")).To(BeFalse())
+		})
+		It("Should reject PCI address with extra characters", func() {
+			Expect(IsPCIAddress("0000:04:00.5/foo")).To(BeFalse())
+		})
+	})
+
+	Describe("IsAuxDevAddress", func() {
+		It("Should accept valid auxiliary device ID", func() {
+			Expect(IsAuxDevAddress("mlx5_core.sf.4")).To(BeTrue())
+		})
+		It("Should accept aux device with numeric module name", func() {
+			Expect(IsAuxDevAddress("123.abc.0")).To(BeTrue())
+		})
+		It("Should accept aux device with ID of 0", func() {
+			Expect(IsAuxDevAddress("mod.name.0")).To(BeTrue())
+		})
+		It("Should accept aux device with large ID", func() {
+			Expect(IsAuxDevAddress("mod.name.99999")).To(BeTrue())
+		})
+		It("Should accept aux device with hyphens and underscores", func() {
+			Expect(IsAuxDevAddress("my-mod_1.dev-name_2.42")).To(BeTrue())
+		})
+		It("Should reject empty string", func() {
+			Expect(IsAuxDevAddress("")).To(BeFalse())
+		})
+		It("Should reject input with only two components", func() {
+			Expect(IsAuxDevAddress("mod.name")).To(BeFalse())
+		})
+		It("Should reject input with four components", func() {
+			Expect(IsAuxDevAddress("a.b.c.1")).To(BeFalse())
+		})
+		It("Should reject input with non-numeric ID", func() {
+			Expect(IsAuxDevAddress("mod.name.abc")).To(BeFalse())
+		})
+		It("Should reject input with trailing newline", func() {
+			Expect(IsAuxDevAddress("mod.name.1\n")).To(BeFalse())
+		})
+		It("Should reject input with leading whitespace", func() {
+			Expect(IsAuxDevAddress(" mod.name.1")).To(BeFalse())
+		})
+		It("Should reject input with path separator", func() {
+			Expect(IsAuxDevAddress("mod/name.sf.1")).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
getRDMADevice accepted any non-PCI deviceID and passed it directly to sysfs path construction via GetRdmaDevsForAuxDev, enabling path traversal. Add IsAuxDevAddress regex validator matching the kernel auxiliary bus naming convention, and reject unrecognized formats.

GetStateRef concatenated network name, container ID, and interface name into cache file paths without validation. Add component validation rejecting forward slashes, backslashes, and dot-dot sequences to prevent cache-file path traversal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid state references during RDMA device addition and removal.
  * RDMA devices are restored to their original namespace when setup encounters an error.
  * Invalid device ID formats now produce clearer errors.
  * Added validation to prevent unsafe state reference components.
  * Improved recognition of PCI and auxiliary device addresses.

* **Tests**
  * Expanded coverage for state reference failures, device address validation, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->