### PR TITLE
fix: remove cached state when DEL has no network namespace

### DIFF
--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -252,12 +252,6 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 	}
 	log.Debug().Msgf("CmdDel() args: %v ", args)
 
-	// Container already exited, so no Namespace. if no Namespace, we got nothing to clean.
-	// this may happen in Infra containers as described in https://github.com/kubernetes/kubernetes/pull/35240
-	if args.Netns == "" {
-		return nil
-	}
-
 	// Load RDMA device state from cache
 	rdmaState := rdmatypes.RdmaNetState{}
 	pRef := plugin.stateCache.GetStateRef(conf.Name, args.ContainerID, args.IfName)
@@ -267,11 +261,14 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 		return nil
 	}
 
-	// Move RDMA device to default namespace
-	err = plugin.moveRdmaDevFromNs(rdmaState.ContainerRdmaDevName, args.Netns)
-	if err != nil {
-		return fmt.Errorf(
-			"failed to restore RDMA device %s to default namespace. %v", rdmaState.ContainerRdmaDevName, err)
+	// An exited container may no longer have a namespace, but its cached state
+	// still needs to be removed.
+	if args.Netns != "" {
+		err = plugin.moveRdmaDevFromNs(rdmaState.ContainerRdmaDevName, args.Netns)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to restore RDMA device %s to default namespace. %v", rdmaState.ContainerRdmaDevName, err)
+		}
 	}
 
 	err = plugin.stateCache.Delete(pRef)

--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -158,7 +158,7 @@ func (plugin *rdmaCniPlugin) moveRdmaDevFromNs(rdmaDev, nsPath string) error {
 		return plugin.rdmaManager.MoveRdmaDevToNs(rdmaDev, targetNs)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to move RDMA device %s to default namespace. %v", rdmaDev, err)
+		return fmt.Errorf("failed to move RDMA device %s to default namespace. %w", rdmaDev, err)
 	}
 	return err
 }
@@ -267,7 +267,7 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 		err = plugin.moveRdmaDevFromNs(rdmaState.ContainerRdmaDevName, args.Netns)
 		if err != nil {
 			return fmt.Errorf(
-				"failed to restore RDMA device %s to default namespace. %v", rdmaState.ContainerRdmaDevName, err)
+				"failed to restore RDMA device %s to default namespace. %w", rdmaState.ContainerRdmaDevName, err)
 		}
 	}
 

--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -273,7 +273,7 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 
 	err = plugin.stateCache.Delete(pRef)
 	if err != nil {
-		log.Warn().Msgf("failed to delete cache entry(%q). %v", pRef, err)
+		return fmt.Errorf("failed to delete cache entry(%q): %w", pRef, err)
 	}
 	return nil
 }

--- a/cmd/rdma/main.go
+++ b/cmd/rdma/main.go
@@ -158,7 +158,7 @@ func (plugin *rdmaCniPlugin) moveRdmaDevFromNs(rdmaDev, nsPath string) error {
 		return plugin.rdmaManager.MoveRdmaDevToNs(rdmaDev, targetNs)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to move RDMA device %s to default namespace. %w", rdmaDev, err)
+		return fmt.Errorf("failed to move RDMA device %s to default namespace: %w", rdmaDev, err)
 	}
 	return err
 }
@@ -267,7 +267,7 @@ func (plugin *rdmaCniPlugin) CmdDel(args *skel.CmdArgs) error {
 		err = plugin.moveRdmaDevFromNs(rdmaState.ContainerRdmaDevName, args.Netns)
 		if err != nil {
 			return fmt.Errorf(
-				"failed to restore RDMA device %s to default namespace. %w", rdmaState.ContainerRdmaDevName, err)
+				"failed to restore RDMA device %s to default namespace: %w", rdmaState.ContainerRdmaDevName, err)
 		}
 	}
 

--- a/cmd/rdma/main_test.go
+++ b/cmd/rdma/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -269,6 +271,25 @@ var _ = Describe("Main", func() {
 	})
 
 	Describe("Test CmdDel()", func() {
+		It("removes cached state when the container namespace is already gone", func() {
+			originalCacheDir := cache.CacheDir
+			cache.CacheDir = GinkgoT().TempDir()
+			DeferCleanup(func() { cache.CacheDir = originalCacheDir })
+			plugin.stateCache = cache.NewStateCache()
+			plugin.nsManager = nil
+			plugin.rdmaManager = nil
+			conf := generateNetConfCmdDel("rdma-net")
+			args := generateArgs("", "container-1", "net1", &conf)
+			ref := plugin.stateCache.GetStateRef(conf.Name, args.ContainerID, args.IfName)
+			state := generateRdmaNetState("0000:04:00.5", "mlx5_4", "mlx5_4")
+			Expect(plugin.stateCache.Save(ref, &state)).To(Succeed())
+
+			Expect(plugin.CmdDel(&args)).To(Succeed())
+			_, err := os.Stat(filepath.Join(cache.CacheDir, string(ref)))
+			Expect(os.IsNotExist(err)).To(BeTrue(), "DEL must remove the cached network state")
+			Expect(plugin.CmdDel(&args)).To(Succeed())
+		})
+
 		Context("Valid configuration provided", func() {
 			It("Should succeed and move Rdma device associated with PCI net device back to sandbox namespace", func() {
 				pciDev := "0000:04:00.5"

--- a/cmd/rdma/main_test.go
+++ b/cmd/rdma/main_test.go
@@ -301,9 +301,10 @@ var _ = Describe("Main", func() {
 			stateCacheMock.On("Delete", ref).Return(deleteErr)
 
 			err := plugin.CmdDel(&args)
-			Expect(err).To(MatchError(ContainSubstring("failed to delete cache entry")))
-			Expect(errors.Is(err, deleteErr)).To(BeTrue())
-			stateCacheMock.AssertExpectations(GinkgoT())
+			Expect(err).To(MatchError(ContainSubstring("failed to delete cache entry")),
+				"DEL must report cache deletion failures")
+			Expect(errors.Is(err, deleteErr)).To(BeTrue(), "DEL must preserve the cache deletion error chain")
+			Expect(stateCacheMock.AssertExpectations(GinkgoT())).To(BeTrue(), "DEL must perform the expected cache operations")
 		})
 
 		It("preserves cached state when restoring the RDMA device fails", func() {
@@ -316,13 +317,17 @@ var _ = Describe("Main", func() {
 				*args.Get(1).(*rdmaTypes.RdmaNetState) = state
 			})
 			targetNs, err := dummyNsMgr.GetCurrentNS()
-			Expect(err).NotTo(HaveOccurred())
-			rdmaMgrMock.On("MoveRdmaDevToNs", state.ContainerRdmaDevName, targetNs).Return(fmt.Errorf("restore failed"))
+			Expect(err).NotTo(HaveOccurred(), "the restore failure fixture must provide the default namespace")
+			restoreErr := errors.New("restore failed")
+			rdmaMgrMock.On("MoveRdmaDevToNs", state.ContainerRdmaDevName, targetNs).Return(restoreErr)
 
-			Expect(plugin.CmdDel(&args)).To(MatchError(ContainSubstring("restore failed")))
-			stateCacheMock.AssertNotCalled(GinkgoT(), "Delete", mock.Anything)
-			stateCacheMock.AssertExpectations(GinkgoT())
-			rdmaMgrMock.AssertExpectations(GinkgoT())
+			err = plugin.CmdDel(&args)
+			Expect(err).To(MatchError(ContainSubstring("restore failed")), "DEL must report device restoration failures")
+			Expect(errors.Is(err, restoreErr)).To(BeTrue(), "DEL must preserve the device restoration error chain")
+			Expect(stateCacheMock.AssertNotCalled(GinkgoT(), "Delete", mock.Anything)).To(BeTrue(),
+				"DEL must retain cached state when device restoration fails")
+			Expect(stateCacheMock.AssertExpectations(GinkgoT())).To(BeTrue(), "DEL must perform the expected cache operations")
+			Expect(rdmaMgrMock.AssertExpectations(GinkgoT())).To(BeTrue(), "DEL must attempt to restore the RDMA device")
 		})
 
 		Context("Valid configuration provided", func() {

--- a/cmd/rdma/main_test.go
+++ b/cmd/rdma/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -288,6 +289,40 @@ var _ = Describe("Main", func() {
 			_, err := os.Stat(filepath.Join(cache.CacheDir, string(ref)))
 			Expect(os.IsNotExist(err)).To(BeTrue(), "DEL must remove the cached network state")
 			Expect(plugin.CmdDel(&args)).To(Succeed())
+		})
+
+		It("returns cache deletion failures when the namespace is already gone", func() {
+			conf := generateNetConfCmdDel("rdma-cleanup-failure")
+			args := generateArgs("", "container-1", "net1", &conf)
+			ref := cache.StateRef("some-ref")
+			deleteErr := fmt.Errorf("cache is read-only")
+			stateCacheMock.On("GetStateRef", conf.Name, args.ContainerID, args.IfName).Return(ref)
+			stateCacheMock.On("Load", ref, mock.Anything).Return(nil)
+			stateCacheMock.On("Delete", ref).Return(deleteErr)
+
+			err := plugin.CmdDel(&args)
+			Expect(err).To(MatchError(ContainSubstring("failed to delete cache entry")))
+			Expect(errors.Is(err, deleteErr)).To(BeTrue())
+			stateCacheMock.AssertExpectations(GinkgoT())
+		})
+
+		It("preserves cached state when restoring the RDMA device fails", func() {
+			conf := generateNetConfCmdDel("rdma-net")
+			args := generateArgs("/proc/12444/ns/net", "container-1", "net1", &conf)
+			ref := cache.StateRef("some-ref")
+			state := generateRdmaNetState("0000:04:00.5", "mlx5_4", "mlx5_4")
+			stateCacheMock.On("GetStateRef", conf.Name, args.ContainerID, args.IfName).Return(ref)
+			stateCacheMock.On("Load", ref, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+				*args.Get(1).(*rdmaTypes.RdmaNetState) = state
+			})
+			targetNs, err := dummyNsMgr.GetCurrentNS()
+			Expect(err).NotTo(HaveOccurred())
+			rdmaMgrMock.On("MoveRdmaDevToNs", state.ContainerRdmaDevName, targetNs).Return(fmt.Errorf("restore failed"))
+
+			Expect(plugin.CmdDel(&args)).To(MatchError(ContainSubstring("restore failed")))
+			stateCacheMock.AssertNotCalled(GinkgoT(), "Delete", mock.Anything)
+			stateCacheMock.AssertExpectations(GinkgoT())
+			rdmaMgrMock.AssertExpectations(GinkgoT())
 		})
 
 		Context("Valid configuration provided", func() {


### PR DESCRIPTION
When the runtime calls DEL after a container's network namespace has gone away, `CNI_NETNS` can be empty. The early return leaves the saved network state under `/var/lib/cni/rdma` indefinitely, even though DEL reports success.

Keep the cache cleanup path active for an empty namespace and skip only moving the RDMA device. A failure to move a device from an existing namespace still returns before deleting its state.

Add a regression test with the real filesystem cache: save network state, call DEL with an empty namespace, check that the file is removed, and repeat DEL to verify it remains idempotent. The file remains on the upstream baseline and is removed with this change. Namespace and RDMA managers are unset in this test, so it also verifies that no device operation is attempted.

Validation:
- `make test-race`
- `make build`
- `make lint` (repository-pinned golangci-lint v2.7.2, 0 issues)

The regression exercises filesystem cleanup and does not require RDMA hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - RDMA cleanup now proceeds even when a container’s network namespace is unavailable.
  - Cleanup can be safely repeated after the namespace has already been removed.
  - Cached state is retained when device restoration fails, preserving accurate error reporting.
  - Cache deletion failures are now reported as errors instead of being silently logged.

- **Tests**
  - Added coverage for unavailable namespaces, repeated cleanup, cache deletion failures, and device restoration failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->